### PR TITLE
Fixing to no map a not find column in cursor

### DIFF
--- a/src/main/java/com/clertonleal/proto/Proto.java
+++ b/src/main/java/com/clertonleal/proto/Proto.java
@@ -151,7 +151,7 @@ public class Proto {
             }
             final String columnName = annotation.columnName();
             final int fieldIndex = cursor.getColumnIndex(columnName);
-            if (fieldIndex > 0) {
+            if (fieldIndex != -1) {
                 columnMap.put(columnName, fieldIndex);
             }
         }

--- a/src/main/java/com/clertonleal/proto/Proto.java
+++ b/src/main/java/com/clertonleal/proto/Proto.java
@@ -151,7 +151,9 @@ public class Proto {
             }
             final String columnName = annotation.columnName();
             final int fieldIndex = cursor.getColumnIndex(columnName);
-            columnMap.put(columnName, fieldIndex);
+            if (fieldIndex > 0) {
+                columnMap.put(columnName, fieldIndex);
+            }
         }
         return columnMap;
     }


### PR DESCRIPTION
The mapper function is now validates if the column name exists in cursor, if doesn't, don't add to mapping
